### PR TITLE
Fix credential leakage with env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ backend/node_modules/
 
 # Сборка
 dist/
+.env
+backend/.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-xvcrm
-fwP5t3Qe!MnpYTq
+# XV CRM
+
+Sample CRM project using Node.js backend with MySQL and a Next.js frontend.
+
+## Setup
+
+1. Copy `backend/.env.example` to `backend/.env` and fill in your database credentials and JWT secret.
+2. Install dependencies in both `backend` and `frontend` directories.
+3. Run `npm run dev` inside `backend` to start the API server.
+4. Run `npm run dev` inside `frontend` to start the web application.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=pass
+DB_NAME=xvcrm
+DB_PORT=3306
+JWT_SECRET=your_jwt_secret
+PORT=5000

--- a/backend/db.ts
+++ b/backend/db.ts
@@ -1,9 +1,12 @@
 import mysql from 'mysql2/promise';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 export const db = mysql.createPool({
-  host: 'db5017842634.hosting-data.io',
-  user: 'dbu2412816',
-  password: 'fwP5t3Qe!MnpYTq',
-  database: 'dbs14225309',
-  port: 3306,
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  port: Number(process.env.DB_PORT) || 3306,
 });

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -51,7 +51,8 @@ app.post('/api/Login', (req: Request, res: Response): void => {
         return res.status(401).json({ message: 'Неверный пароль' });
       }
 
-      const token = jwt.sign({ id: user.id }, 'secret123', { expiresIn: '1h' });
+      const secret = process.env.JWT_SECRET || 'secret';
+      const token = jwt.sign({ id: user.id }, secret, { expiresIn: '1h' });
 
       res.json({ token });
     } catch (error) {


### PR DESCRIPTION
## Summary
- secure database connection and JWT secret via environment variables
- update README with setup instructions
- ignore local env files

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'mysql2/promise', etc.)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683f781f4f948328aad3cbe14715edbd